### PR TITLE
make property of data field generic

### DIFF
--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/BooleanField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/BooleanField.java
@@ -21,9 +21,7 @@ package com.dlsc.formsfx.model.structure;
  */
 
 import com.dlsc.formsfx.view.controls.SimpleBooleanControl;
-import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
-import javafx.util.StringConverter;
 
 /**
  * This class provides an implementation of a {@link Field} containing a
@@ -32,7 +30,7 @@ import javafx.util.StringConverter;
  * @author Sacha Schmid
  * @author Rinesch Murugathas
  */
-public class BooleanField extends DataField<BooleanProperty, Boolean, BooleanField> {
+public class BooleanField extends DataField<Boolean, BooleanField> {
 
     /**
      * The constructor of {@code BooleanField}.

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DataField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DataField.java
@@ -45,7 +45,7 @@ import java.util.stream.Collectors;
  * @author Sacha Schmid
  * @author Rinesch Murugathas
  */
-public abstract class DataField<P extends Property, V, F extends Field<F>> extends Field<F> {
+public abstract class DataField<V, F extends Field<F>> extends Field<F> {
   
     /**
      * Every field tracks its value in multiple ways.
@@ -59,8 +59,8 @@ public abstract class DataField<P extends Property, V, F extends Field<F>> exten
      *   is the responsibility of the form creator to persist the field values
      *   at the correct time.
      */
-    protected final P value;
-    protected final P persistentValue;
+    protected final Property<V> value;
+    protected final Property<V> persistentValue;
     protected final StringProperty userInput = new SimpleStringProperty("");
 
     /**
@@ -96,7 +96,7 @@ public abstract class DataField<P extends Property, V, F extends Field<F>> exten
     /**
      * This listener updates the field when the external binding changes.
      */
-    private final InvalidationListener externalBindingListener = (observable) -> userInput.setValue(stringConverter.toString((V) ((P) observable).getValue()));
+    private final InvalidationListener externalBindingListener = (observable) -> userInput.setValue(stringConverter.toString(((Property<V>) observable).getValue()));
 
     /**
      * Internal constructor for the {@code DataField} class. To create new
@@ -114,7 +114,7 @@ public abstract class DataField<P extends Property, V, F extends Field<F>> exten
      *              The property that is used to store the latest persisted
      *              value of the field.
      */
-    protected DataField(P valueProperty, P persistentValueProperty) {
+    protected DataField(Property<V> valueProperty, Property<V> persistentValueProperty) {
         value = valueProperty;
         persistentValue = persistentValueProperty;
 
@@ -295,7 +295,7 @@ public abstract class DataField<P extends Property, V, F extends Field<F>> exten
      *
      * @return Returns the current field to allow for chaining.
      */
-    public F bind(P binding) {
+    public F bind(Property<V> binding) {
         persistentValue.bindBidirectional(binding);
         binding.addListener(externalBindingListener);
 
@@ -310,7 +310,7 @@ public abstract class DataField<P extends Property, V, F extends Field<F>> exten
      *
      * @return Returns the current field to allow for chaining.
      */
-    public F unbind(P binding) {
+    public F unbind(Property<V> binding) {
         persistentValue.unbindBidirectional(binding);
         binding.removeListener(externalBindingListener);
 
@@ -455,7 +455,7 @@ public abstract class DataField<P extends Property, V, F extends Field<F>> exten
         return (V) value.getValue();
     }
 
-    public P valueProperty() {
+    public Property<V> valueProperty() {
         return value;
     }
 

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DateField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DateField.java
@@ -22,8 +22,7 @@ package com.dlsc.formsfx.model.structure;
 
 import com.dlsc.formsfx.view.controls.SimpleDateControl;
 import javafx.beans.property.ObjectProperty;
-import javafx.beans.value.ChangeListener;
-import javafx.beans.value.ObservableValue;
+import javafx.beans.property.Property;
 import javafx.util.converter.LocalDateStringConverter;
 
 import java.time.LocalDate;
@@ -36,7 +35,7 @@ import java.util.Locale;
  *
  * @author Tomasz Krzemiński
  */
-public class DateField extends DataField<ObjectProperty<LocalDate>, LocalDate, DateField> {
+public class DateField extends DataField<LocalDate, DateField> {
     /**
      * Internal constructor for the {@code DataField} class. To create new
      * elements, see the static factory methods in {@code Field}.
@@ -56,11 +55,11 @@ public class DateField extends DataField<ObjectProperty<LocalDate>, LocalDate, D
         stringConverter = new LocalDateStringConverter(FormatStyle.SHORT, null, chronology);
         renderer = new SimpleDateControl();
         userInput.setValue(null);
-        userInput.setValue(stringConverter.toString((LocalDate) persistentValue.getValue()));
+        userInput.setValue(stringConverter.toString(persistentValue.getValue()));
     }
 
     @Override
-    public DateField bind(ObjectProperty<LocalDate> binding) {
+    public DateField bind(Property<LocalDate> binding) {
         return super.bind(binding);
 
     }

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DoubleField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DoubleField.java
@@ -22,7 +22,7 @@ package com.dlsc.formsfx.model.structure;
 
 import com.dlsc.formsfx.view.controls.SimpleDoubleControl;
 import javafx.beans.property.DoubleProperty;
-import javafx.beans.property.SimpleDoubleProperty;
+import javafx.beans.property.Property;
 
 /**
  * This class provides an implementation of a {@link Field} containing a
@@ -31,7 +31,7 @@ import javafx.beans.property.SimpleDoubleProperty;
  * @author Sacha Schmid
  * @author Rinesch Murugathas
  */
-public class DoubleField extends DataField<DoubleProperty, Double, DoubleField> {
+public class DoubleField extends DataField<Double, DoubleField> {
 
     /**
      * The constructor of {@code DoubleField}.
@@ -43,8 +43,8 @@ public class DoubleField extends DataField<DoubleProperty, Double, DoubleField> 
      *              The property that is used to store the latest persisted
      *              value of the field.
      */
-    protected DoubleField(SimpleDoubleProperty valueProperty, SimpleDoubleProperty persistentValueProperty) {
-        super(valueProperty, persistentValueProperty);
+    protected DoubleField(DoubleProperty valueProperty, DoubleProperty persistentValueProperty) {
+        super((Property<Double>) (Property)valueProperty, (Property<Double>) (Property)persistentValueProperty);
 
         stringConverter = new AbstractStringConverter<Double>() {
             @Override

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Field.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Field.java
@@ -32,15 +32,12 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
-import javafx.collections.ObservableList;
 import javafx.event.EventHandler;
 import javafx.event.EventType;
 import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.control.Labeled;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -264,7 +261,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
      * @return Returns a new {@link DoubleField}.
      */
     public static DoubleField ofDoubleType(DoubleProperty binding) {
-        return new DoubleField(new SimpleDoubleProperty(binding.getValue()), new SimpleDoubleProperty(binding.getValue())).bind(binding);
+        return new DoubleField(new SimpleDoubleProperty(binding.getValue()), new SimpleDoubleProperty(binding.getValue())).bind((Property<Double>) (Property)binding);
     }
 
     /**
@@ -288,7 +285,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
      * @return Returns a new {@link IntegerField}.
      */
     public static IntegerField ofIntegerType(IntegerProperty binding) {
-        return new IntegerField(new SimpleIntegerProperty(binding.getValue()), new SimpleIntegerProperty(binding.getValue())).bind(binding);
+        return new IntegerField(new SimpleIntegerProperty(binding.getValue()), new SimpleIntegerProperty(binding.getValue())).bind((Property<Integer>) (Property)binding);
     }
 
     /**

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/IntegerField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/IntegerField.java
@@ -23,7 +23,7 @@ package com.dlsc.formsfx.model.structure;
 
 import com.dlsc.formsfx.view.controls.SimpleIntegerControl;
 import javafx.beans.property.IntegerProperty;
-import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.Property;
 
 /**
  * This class provides an implementation of a {@link Field} containing a
@@ -32,7 +32,7 @@ import javafx.beans.property.SimpleIntegerProperty;
  * @author Sacha Schmid
  * @author Rinesch Murugathas
  */
-public class IntegerField extends DataField<IntegerProperty, Integer, IntegerField> {
+public class IntegerField extends DataField<Integer, IntegerField> {
 
     /**
      * The constructor of {@code IntegerField}.
@@ -44,8 +44,8 @@ public class IntegerField extends DataField<IntegerProperty, Integer, IntegerFie
      *              The property that is used to store the latest persisted
      *              value of the field.
      */
-    protected IntegerField(SimpleIntegerProperty valueProperty, SimpleIntegerProperty persistentValueProperty) {
-        super(valueProperty, persistentValueProperty);
+    protected IntegerField(IntegerProperty valueProperty, IntegerProperty persistentValueProperty) {
+        super((Property<Integer>) (Property)valueProperty, (Property<Integer>) (Property)persistentValueProperty);
 
         stringConverter = new AbstractStringConverter<Integer>() {
             @Override

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/PasswordField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/PasswordField.java
@@ -21,11 +21,7 @@ package com.dlsc.formsfx.model.structure;
  */
 
 import com.dlsc.formsfx.view.controls.SimplePasswordControl;
-import com.dlsc.formsfx.view.controls.SimpleTextControl;
-import javafx.beans.property.BooleanProperty;
-import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
-import javafx.beans.property.StringProperty;
 
 /**
  * This class provides an implementation of a {@link Field} containing a
@@ -33,7 +29,7 @@ import javafx.beans.property.StringProperty;
  *
  * @author Andres Almiray
  */
-public class PasswordField extends DataField<StringProperty, String, PasswordField> {
+public class PasswordField extends DataField<String, PasswordField> {
     /**
      * The constructor of {@code PasswordField}.
      *

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/StringField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/StringField.java
@@ -24,7 +24,6 @@ import com.dlsc.formsfx.view.controls.SimpleTextControl;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
-import javafx.beans.property.StringProperty;
 
 /**
  * This class provides an implementation of a {@link Field} containing a
@@ -33,7 +32,7 @@ import javafx.beans.property.StringProperty;
  * @author Sacha Schmid
  * @author Rinesch Murugathas
  */
-public class StringField extends DataField<StringProperty, String, StringField> {
+public class StringField extends DataField<String, StringField> {
 
     protected final BooleanProperty multiline = new SimpleBooleanProperty(false);
 


### PR DESCRIPTION
This PR consists only of a breaking change.
Never the less I would like to discuss the possibility to get this merged.

## Breaking Change
* Remove generic parameter `P` from `DataField`. This was the type of the property which was used in the DataField. The new implementation works with any Property<V> and therefore is no longer dependent onto the exact type P.

I do not think this breaking changes will have much influence on users because the change is only noticeable if someone sub-class DataField instead of using one of the provided sub-classes.


