### PR TITLE
add generic parameter to return value of SelectionField.getItems()

### DIFF
--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/SelectionField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/SelectionField.java
@@ -106,7 +106,7 @@ public abstract class SelectionField<V, F extends SelectionField<V, F>> extends 
         return true;
     }
 
-    public ObservableList getItems() {
+    public ObservableList<V> getItems() {
         return items.get();
     }
 

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleListViewControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleListViewControl.java
@@ -44,7 +44,7 @@ public class SimpleListViewControl<V> extends SimpleControl<MultiSelectionField<
      * - The listView is the container that displays list values.
      */
     protected Label fieldLabel;
-    protected ListView<String> listView = new ListView<>();
+    protected ListView<V> listView = new ListView<>();
 
     /**
      * The flag used for setting the selection properly.


### PR DESCRIPTION
This PR consists only of a breaking change.
Never the less I would like to discuss the possibility to get this merged.

## Breaking Change
* Add generic parameter to return value of `SelectionField.getItems()`.
* Convert listView from `ListView<String>` to `ListView<V>` as it must be able to hold the items from the SelectionField

I am uncertain on how this will impact clients. Never the less the existing implementation is dangerous as it allows to add any type int the `ListView<String>`.